### PR TITLE
Revised partStatus translations

### DIFF
--- a/locales/en/inbox.json
+++ b/locales/en/inbox.json
@@ -73,21 +73,14 @@
       "partialFramework": "Partial Framework"
     },
     "partStatus": {
-      "uploadPending": "Upload pending",
-      "uploaded": "Uploaded",
-      "preProcessing": "Pre-processing",
-      "toConfirm": "To confirm",
-      "toAccept": "To accept",
-      "accepted": "Accepted",
-      "rejected": "Rejected",
       "processing": "Processing",
-      "awaitingPlacement": "Awaiting Placement",
-      "placing": "Placing",
-      "placed": "Placed",
-      "printing": "Printing",
+      "toConfirm": "To confirm",
+      "pendingAcceptance": "Pending acceptance",
+      "printReady": "Print ready",
+      "addedToJob": "Added to job",
       "printed": "Printed",
-      "failed": "Failed",
-      "offline": "Offline"
+      "reworkedOffline": "Reworked offline",
+      "rejected": "Rejected"
     }
   },
   "title": {


### PR DESCRIPTION
Revised the Part Status translations to only reflect the UI status', rather than all of the code status'.

i.e., Only including all of the black dot points below, not the indented status codes:
![image](https://github.com/Zydex/asiga-i18n/assets/163782303/8b84acc0-1132-49bc-84e8-b8054fd27221)
