### PR TITLE
Fix: WP-86 Persist Uploads Dialogue - Added Bulk Cancel Dialogue Translations

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -171,7 +171,11 @@
     "itemSelected": "Item selected",
     "itemSelected_one": "{{count}} item selected",
     "itemSelected_other": "{{count}} items selected",
-    "itemSelected_zero": "No items selected"
+    "itemSelected_zero": "No items selected",
+    "cancelUploadsModalTitle": "Cancel remaining uploads?",
+    "cancelUploadsModalBody": "Part uploads are not complete. Would you like to cancel the remaining uploads?",
+    "cancelUploadsModalButtonPrimary": "Cancel Uploads",
+    "cancelUploadModalButtonSecondary": "Continue Uploads"
   },
   "links": {
     "devices": "Devices",


### PR DESCRIPTION
YouTrack Issue: [WP-86](https://zydex.youtrack.cloud/issue/WP-86/UX-QA-Upload-Dialogue-should-persist-across-pages)
Added translations to the cancel all uploads dialogue window:
![image](https://github.com/user-attachments/assets/f8cbca2d-336e-45e3-b8ee-9221a31051b4)
