### PR TITLE
fix(inbox.json): updated empty inbox confirm tab wording

### DIFF
--- a/locales/en/inbox.json
+++ b/locales/en/inbox.json
@@ -40,8 +40,8 @@
   },
   "emptyInboxMessages": {
     "confirm": {
-      "title": "No parts",
-      "message": "Use the 'Upload Parts' button at the top right of this page or use the button below to add parts to your organisation"
+      "title": "No parts to confirm",
+      "message": "Use the 'Upload Parts' button or drag and drop files, to add parts to your organisation"
     },
     "review": {
       "title": "No parts to review",


### PR DESCRIPTION
Jira: [AWF-847](https://asiga.atlassian.net/browse/AWF-847?atlOrigin=eyJpIjoiMjljY2QyZDc0ZDc4NDkyMDkxMjUwNzBkYmE0ZmQ3MzciLCJwIjoiaiJ9)

> Ideal behaviour (text):
> No parts to confirm
> Use the ‘Upload Parts’ button or drag and drop files, to add parts to your organisation