### PR TITLE
fix: AWF-787 Part upload dialogue filter STLs

### DIFF
--- a/locales/en/inbox.json
+++ b/locales/en/inbox.json
@@ -33,6 +33,7 @@
     "rejected": "Rejected",
     "search": "Search for a part",
     "dropFile": "Add file to the Inbox",
+    "invalidUploadFileType": "Only STL files are supported",
     "preparingDownload": "Preparing download",
     "designSelected_one": "{{count}} Design selected",
     "designSelected_other": "{{count}} Designs selected",


### PR DESCRIPTION
- Translation for invalid file types on upload.
- Required for [Web-Portal-PR-205](https://github.com/Zydex/asiga-web-portal/pull/205)