### PR TITLE
AWF-843 Timeline Hours Dropdown

### DIFF
--- a/locales/en/timeline.json
+++ b/locales/en/timeline.json
@@ -6,6 +6,6 @@
     "title": {
       "timeline": "Timeline"
     },
-    "viewHours": "Hours"
+    "viewHours_other": "{{count}} hour view"
   }
   

--- a/locales/en/timeline.json
+++ b/locales/en/timeline.json
@@ -6,6 +6,6 @@
     "title": {
       "timeline": "Timeline"
     },
-    "viewHours_other": "{{count}} hour view"
+    "viewHours_other": "{{count}} Hour view"
   }
   


### PR DESCRIPTION
fix(timeline.json): correct view-hours translation

Required for: https://github.com/Zydex/asiga-web-portal/compare/AWF-843-Timeline-Hours-Dropdown