### PR TITLE
fix: AWF-886 missing translations

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -161,6 +161,7 @@
     "templateDeleteForbidden": "You are not allowed to delete a template for this organisation."
   },
   "label": {
+    "tabs": "Tabs",
     "fullname": "Full Name",
     "locale": "Locale",
     "openDrawer": "Open Drawer",


### PR DESCRIPTION
Found:
- `inbox.label.uploadCancelled`
- `error.unspecified`
Added:
- `common:label.tabs`