### PR TITLE
fix: AWF-930 Added 'Rejected' To Part Progress Statuses

### DIFF
--- a/locales/en/parts.json
+++ b/locales/en/parts.json
@@ -65,7 +65,8 @@
             "printing": "Printing",
             "printed": "Printed",
             "printFailed": "Print failed"
-        }
+        },
+        "rejected": "Rejected"
     }
   }
   


### PR DESCRIPTION
fix(parts.json): added rejected status to part-progress-statuses instead of requiring inbox translations