### PR TITLE
fix(inbox.json): consistent review tab naming

### DIFF
--- a/locales/en/inbox.json
+++ b/locales/en/inbox.json
@@ -30,7 +30,7 @@
   },
   "label": {
     "confirm": "Confirm",
-    "review": "Review",
+    "review": "To Review",
     "accepted": "Accepted",
     "rejected": "Rejected",
     "search": "Search for a part",


### PR DESCRIPTION
No Jira ticket but David wanted the `Inbox` and `Jobs` pages to have a consistent tab name for the `To Review` tab