### PR TITLE
feat: AWF-1163 Add translation strings for display error

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -166,6 +166,10 @@
     "message_wide": "Check the page address for typos or use the navigation buttons on the left",
     "message_narrow": "Check the page address for typos or use the navigation menu on the top left"
   },
+  "displayError": {
+    "message": "Check connection and try refreshing the web page.\nContact support if the problem continues.",
+    "button": "Contact Support"
+  },
   "label": {
     "tabs": "Tabs",
     "fullname": "Full Name",


### PR DESCRIPTION
Jira: [AWF-1163](https://asiga.atlassian.net/browse/AWF-1163)

Required for: https://github.com/Zydex/asiga-web-portal/pull/302


Strings for the design of the error display.

![image](https://github.com/user-attachments/assets/123a2923-60d2-4ec4-82fb-ecaf5e1cfb1f)

Note that the Title part is translated separately depending on error key and/or status for the particular error.

AWF-1163

[AWF-1163]: https://asiga.atlassian.net/browse/AWF-1163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ