### PR TITLE
fix: AWF-968 updated trial ending translations

### DIFF
--- a/locales/en-au/subscription.json
+++ b/locales/en-au/subscription.json
@@ -24,6 +24,7 @@
     "subscriptionStatus": "Subscription Status",
     "subscriptionTiers": "Subscription Tiers",
     "trialEnded": "Trial has ended",
+    "trialEnding_zero": "Trial is ending today",
     "trialEnding_one": "Trial ending in {{count}} day",
     "trialEnding_other": "Trial ending in {{count}} days",
     "trialEndingUnknown": "Trial ending soon"

--- a/locales/en-au/subscription.json
+++ b/locales/en-au/subscription.json
@@ -24,7 +24,8 @@
     "subscriptionStatus": "Subscription Status",
     "subscriptionTiers": "Subscription Tiers",
     "trialEnded": "Trial has ended",
-    "trialEnding": "Trial ending in {{amount}} days",
-    "trialEndingUnknown": "Trial ending"
+    "trialEnding_one": "Trial ending in {{count}} day",
+    "trialEnding_other": "Trial ending in {{count}} days",
+    "trialEndingUnknown": "Trial ending soon"
   }
 }


### PR DESCRIPTION
Jira: [AWF-968](https://asiga.atlassian.net/browse/AWF-968)

Was missing singular version instead of trial ending "in 1 days".

[AWF-968]: https://asiga.atlassian.net/browse/AWF-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ