### PR TITLE
fix: auto-accept rules translations

### DIFF
--- a/locales/en-au/rules.json
+++ b/locales/en-au/rules.json
@@ -1,12 +1,12 @@
 {
   "approvals": {
     "jobs": {
-      "message": "When enabled, print jobs will automatically be sent to a printer, without any user review.",
-      "title": "Approve created print jobs"
+      "message": "When enabled, print jobs are accepted automatically and sent to a printer.",
+      "title": "Auto accept jobs"
     },
     "parts": {
-      "message": "When enabled, parts will be accepted and have templates applied automatically.",
-      "title": "Approve parts for manufacture"
+      "message": "When enabled, parts with a template are accepted automatically for manufacture.",
+      "title": "Auto accept parts"
     },
     "title": "Approvals",
     "tooltips": {


### PR DESCRIPTION
The existing translations were confusing as the titles implied the opposite of the enabled state. Discussed with David and he approved the new translations:

| Before | After |
| --- | --- |
| <img width="542" height="343" alt="Screenshot from 2026-06-24 09-10-42" src="https://github.com/user-attachments/assets/35d7c64c-4503-41d9-ad18-d73550794336" /> | <img width="542" height="349" alt="Screenshot from 2026-06-24 09-10-20" src="https://github.com/user-attachments/assets/f26665cf-75d3-444b-879e-0e2f3c8565cc" /> |